### PR TITLE
Do not call deprecated methode `get_template_vars()` when its replacement exists

### DIFF
--- a/Civi/Mailattachment/Form/Attachments.php
+++ b/Civi/Mailattachment/Form/Attachments.php
@@ -64,7 +64,11 @@ class Attachments
           $form->set('attachments', $attachments);
         }
 
-        $attachment_forms = $form->get_template_vars('attachment_forms') ?? [];
+        $attachment_forms = (
+            (method_exists($form, 'getTemplateVars'))
+                ? $form->getTemplateVars('attachment_forms')
+                : $form->get_template_vars('attachment_forms')
+        ) ?? [];
         foreach ($attachments[$prefix] as $attachment_id => $attachment) {
             if (!$attachment_type = $attachment_types[$attachment['type']] ?? null) {
                 throw new Exception(E::ts('Unregistered attachment type %1', [1 => $attachment['type']]));


### PR DESCRIPTION
Fixes #3.

The replacement method `getTemplateVars()` only exists since version `5.70`, so adding a check retains backwards-compatibility with older Core versions.